### PR TITLE
drop: removed pictor from documentation

### DIFF
--- a/documentation_repositories.txt
+++ b/documentation_repositories.txt
@@ -1,4 +1,3 @@
 https://github.com/code0-tech/telescopium
-https://github.com/code0-tech/pictor
 https://github.com/code0-tech/sagittarius
 https://github.com/code0-tech/aquila

--- a/projects/docs-landing-page/docs/content/index.mdx
+++ b/projects/docs-landing-page/docs/content/index.mdx
@@ -7,9 +7,6 @@ template: splash
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
-    <Card title='<a href="pictor/">Pictor</a>' icon="document">
-        Documentation about the component library.
-    </Card>
     <Card title='<a href="sagittarius/">Sagittarius</a>' icon="rocket">
         Documentation about the backend.
     </Card>


### PR DESCRIPTION
Resolves #57

Is there something missing in this repository, that should be removed? (Except the pipeline in Gitlab & the docs files in the pictor repository)